### PR TITLE
v5.3.0 support and Options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network_vis",
-  "version": "5.0.0",
+  "version": "5.3.0",
   "authors": [
   "David Moreno Lumbreras <dmorenolumb@gmail.com>"
   ],
@@ -10,8 +10,8 @@
     "url": "https://github.com/dlumbrer/kbn_network"
   },
   "dependencies" : {
-    "vis": "4.16.1",
-    "randomcolor": "0.4.4",
+    "vis": "4.19.1",
+    "randomcolor": "0.5.0",
     "css-element-queries": "0.3.2"
   }
 }

--- a/public/network_vis.js
+++ b/public/network_vis.js
@@ -55,8 +55,8 @@ function NetworkVisTypeProvider(Private) {
         minNodeSize: 8,
         maxEdgeSize: 20,
         minEdgeSize: 0.1,
-        springConstant: 0.04,
-        gravitationalConstant: -2000
+        springConstant: 0.001,
+        gravitationalConstant: -35000
       },
       editor: networkVisParamsTemplate
     },

--- a/public/network_vis.js
+++ b/public/network_vis.js
@@ -37,11 +37,17 @@ function NetworkVisTypeProvider(Private) {
         showLabels: true,
         showPopup: false,
         showColorLegend: true,
+        nodePhysics: false,
         firstNodeColor: '#FD7BC4',
         secondNodeColor: '#00d1ff',
         canvasBackgroundColor: '#FFFFFF',
         shapeFirstNode: 'dot',
         shapeSecondNode: 'box',
+        displayArrow: false,
+        posArrow: 'to',
+        shapeArrow: 'arrow',
+        smoothType: 'continuous',
+        scaleArrow: 1,
         maxCutMetricSizeNode: 5000,
         maxCutMetricSizeEdge: 5000,
         minCutMetricSizeNode: 0,
@@ -49,8 +55,8 @@ function NetworkVisTypeProvider(Private) {
         minNodeSize: 8,
         maxEdgeSize: 20,
         minEdgeSize: 0.1,
-        springConstant: 0.001,
-        gravitationalConstant: -35000
+        springConstant: 0.04,
+        gravitationalConstant: -2000
       },
       editor: networkVisParamsTemplate
     },

--- a/public/network_vis_controller.js
+++ b/public/network_vis_controller.js
@@ -1,596 +1,653 @@
 define(function (require) {
-  // get the kibana/table_vis module, and make sure that it requires the "kibana" module if it
-  // didn't already
-  const module = require('ui/modules').get('kibana/network_vis', ['kibana']);
-
-  //import the npm modules
-  const visN = require('vis');
-  const randomColor = require('randomcolor');
-  const ElementQueries = require('css-element-queries/src/ElementQueries');
-  const ResizeSensor = require('css-element-queries/src/ResizeSensor');
-
-
-  // add a controller to tha module, which will transform the esResponse into a
-  // tabular format that we can pass to the table directive
-  module.controller('KbnNetworkVisController', function ($scope, $sce, Private) {
-    var network_id = "net_" + $scope.$id;
-    var loading_id = "loading_" + $scope.$parent.$id;
-
-    $scope.errorNodeColor = function(){
-      $("#" + network_id).hide();
-      $("#" + loading_id).hide();
-      $("#errorHtml").html("<h1><strong>ERROR</strong>: Node Color must be the LAST selection</h1>");
-      $("#errorHtml").show();
-
-    }
-
-    $scope.errorNodeNodeRelation = function(){
-      $("#" + network_id).hide();
-      $("#" + loading_id).hide();
-      $("#errorHtml").html("<h1><strong>ERROR</strong>: You can only choose Node-Node or Node-Relation</h1>");
-      $("#errorHtml").show();
-    }
-
-    $scope.initialShows = function(){
-      $("#" + network_id).show();
-      $("#" + loading_id).show();
-      $("#errorHtml").hide();
-    }
-
-    $scope.startDynamicResize = function(network){
-      for (i = 0; i < $(".vis-container" ).length; i++) {
-         if($(".vis-container")[i].children[0].children[1] && $(".vis-container")[i].children[0].children[1].id == network_id){
-           var viscontainer = $(".vis-container")[i];
-           break;
-         }
-      };
-      new ResizeSensor(viscontainer, function() {
-          network.setSize('100%', viscontainer.clientHeight);
-      });
-    }
-
-    $scope.drawColorLegend = function(usedColors, colorDicc){
-       var canvas = document.getElementsByTagName("canvas")[0];
-       var context = canvas.getContext("2d");
-
-       context.fillStyle="#FFE8D6";
-       var totalheight = usedColors.length * 25
-       context.fillRect(canvas.width*(-2)-10, canvas.height*(-2)-18, 350, totalheight);
-
-       context.fillStyle = "black";
-       context.font = "bold 30px Arial";
-       context.textAlign = "start";
-       context.fillText("LEGEND OF COLORS:", canvas.width*(-2), canvas.height*(-2));
-
-       var p=canvas.height*(-2) + 40;
-       for(var key in colorDicc){
-         context.fillStyle = colorDicc[key];
-         context.font = "bold 20px Arial";
-         context.fillText(key, canvas.width*(-2), p);
-         p = p +22;
-       }
-    }
-
-
-   $scope.$watchMulti(['esResponse', 'vis.params'], function ([resp]) {
-      if (resp) {
-        $("#" + loading_id).hide();
-        if($scope.vis.aggs.bySchemaName['first'].length >= 1 && !$scope.vis.aggs.bySchemaName['second']){ //This is when we have 2 nodes
-            $scope.initialShows();
-            $(".secondNode").show();
-            // Retrieve the id of the configured tags aggregation
-            var firstFieldAggId = $scope.vis.aggs.bySchemaName['first'][0].id;
-            if($scope.vis.aggs.bySchemaName['first'].length > 1){
-              var secondFieldAggId = $scope.vis.aggs.bySchemaName['first'][1].id;
-            }
-
-            if($scope.vis.aggs.bySchemaName['colornode']){
-              var colorNodeAggId = $scope.vis.aggs.bySchemaName['colornode'][0].id;
-              var colorNodeAggName = $scope.vis.aggs.bySchemaName['colornode'][0].params.field.displayName;
-              var colorDicc = {};
-              var usedColors = [];
-            }
-
-            //Names of the terms that have been selected
-            var firstFieldAggName = $scope.vis.aggs.bySchemaName['first'][0].params.field.displayName;
-            if($scope.vis.aggs.bySchemaName['first'].length > 1){
-              var secondFieldAggName = $scope.vis.aggs.bySchemaName['first'][1].params.field.displayName;
-            }
-
-            // Retrieve the metrics aggregation configured
-            if($scope.vis.aggs.bySchemaName['size_node']){
-              var metricsAgg_sizeNode = $scope.vis.aggs.bySchemaName['size_node'][0];
-            }
-            if($scope.vis.aggs.bySchemaName['size_edge']){
-              var metricsAgg_sizeEdge = $scope.vis.aggs.bySchemaName['size_edge'][0];
-            }
-
-            // Get the buckets of that aggregation
-            var buckets = resp.aggregations[firstFieldAggId].buckets;
-
-            //////////////////////////////////////////////////DATA PARSED AND BULDING NODES//////////////////////////////////////////////////////////
-            var dataParsed = [];
-            // Iterate the buckets
-            var i = 0;
-            var dataNodes = buckets.map(function(bucket) {
-
-              dataParsed[i] = {};
-              dataParsed[i].keyFirstNode = bucket.key;
-
-
-              //Metrics are for the sizes
-              if(metricsAgg_sizeNode){
-                // Use the getValue function of the aggregation to get the value of a bucket
-                var value = metricsAgg_sizeNode.getValue(bucket);
-                var sizeVal = Math.min($scope.vis.params.maxCutMetricSizeNode, value);
-
-                //No show nodes under the value
-                if($scope.vis.params.minCutMetricSizeNode > value){
-                  dataParsed.splice(i, 1);
-                  return;
-                }
-              }else{
-                var sizeVal = 20;
-              }
-
-              dataParsed[i].valorSizeNode = sizeVal;
-              dataParsed[i].nodeColorValue = "default";
-              dataParsed[i].nodeColorKey = "default";
-
-
-              //Iterate subbucket and choose the edge size
-              if($scope.vis.aggs.bySchemaName['first'].length > 1){
-                dataParsed[i].relationWithSecondNode = bucket[secondFieldAggId].buckets.map(function(buck) {
-                  if(metricsAgg_sizeEdge){
-                    var value_sizeEdge = metricsAgg_sizeEdge.getValue(buck);
-                    var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
-                  }else{
-                    var sizeEdgeVal = 0.1;
-                  }
-
-                  //Get the color of the node, save in the diccionary
-                  if(colorNodeAggId && buck[colorNodeAggId].buckets.length > 0){
-                    if(colorDicc[buck[colorNodeAggId].buckets[0].key]){
-                      dataParsed[i].nodeColorKey = buck[colorNodeAggId].buckets[0].key;
-                      dataParsed[i].nodeColorValue = colorDicc[buck[colorNodeAggId].buckets[0].key];
-                    }else{
-                      //repeat to find a NO-REPEATED color
-                      while(true){
-                        var confirmColor = randomColor();
-                        if(usedColors.indexOf(confirmColor) == -1){
-                          colorDicc[buck[colorNodeAggId].buckets[0].key] = confirmColor;
-                          dataParsed[i].nodeColorKey = buck[colorNodeAggId].buckets[0].key;
-                          dataParsed[i].nodeColorValue = colorDicc[buck[colorNodeAggId].buckets[0].key];
-                          usedColors.push(confirmColor);
-                          break;
-                        }
-                      }
-
-                    }
-                  }
-
-                  return {
-                    keySecondNode: buck.key,
-                    countMetric: buck.doc_count,
-                    widthOfEdge: sizeEdgeVal
-                  };
-                });
-              }
-
-              //assing color and the content of the popup
-              var inPopup = "<p>" + bucket.key + "</p>"
-              if(dataParsed[i].nodeColorValue != "default"){
-                var colorNodeFinal = dataParsed[i].nodeColorValue;
-                inPopup += "<p>" + dataParsed[i].nodeColorKey + "</p>";
-              }else{
-                var colorNodeFinal = $scope.vis.params.firstNodeColor;
-              }
-
-              i++;
-              //Return the node totally builded
-              var nodeReturn = {
-                id: i,
-                key: bucket.key,
-                color: colorNodeFinal,
-                shape: $scope.vis.params.shapeFirstNode,
-                //size: sizeVal
-                value: sizeVal
-              }
-
-              //If activated, show the labels
-              if($scope.vis.params.showLabels){
-                nodeReturn.label = bucket.key;
-              }
-
-              //If activated, show the popups
-              if($scope.vis.params.showPopup){
-                nodeReturn.title = inPopup;
-              }
-
-              return nodeReturn;
-            });
-            ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-            //////////////////////////////////////////////////BULDING EDGES//////////////////////////////////////////////////////////
-            //Clean "undefinded" in the array
-            dataNodes = dataNodes.filter(Boolean);
-            var dataEdges = [];
-            for(var n = 0; n<dataParsed.length; n++){
-              //Find in the array the node with the keyFirstNode
-              var result = $.grep(dataNodes, function(e){ return e.key == dataParsed[n].keyFirstNode;   });
-              if (result.length == 0) {
-                console.log("Error: Node not finded");
-              } else if (result.length == 1) {
-                //Finded the node, access to its id
-                if($scope.vis.aggs.bySchemaName['first'].length > 1){
-                  for(var r = 0; r<dataParsed[n].relationWithSecondNode.length; r++){
-                    //Find in the relations the second node to relate
-                    var nodeOfSecondType = $.grep(dataNodes, function(e){ return e.key == dataParsed[n].relationWithSecondNode[r].keySecondNode;   });
-                    if (nodeOfSecondType.length == 0) {
-                      //Not finded, added to the DataNodes - node of type 2
-                      i++;
-                      var newNode = {
-                        id : i,
-                        key: dataParsed[n].relationWithSecondNode[r].keySecondNode,
-                        label : dataParsed[n].relationWithSecondNode[r].keySecondNode,
-                        color: $scope.vis.params.secondNodeColor,
-                        shape: $scope.vis.params.shapeSecondNode
-                      };
-                      //Add new node
-                      dataNodes.push(newNode);
-                      //And create the relation (edge)
-                      var edge = {
-                        from : result[0].id,
-                        to : dataNodes[dataNodes.length-1].id,
-                        value: dataParsed[n].relationWithSecondNode[r].widthOfEdge
-                      }
-                      dataEdges.push(edge);
-
-                    } else if (nodeOfSecondType.length == 1) {
-                      //Exist the node, create only the edge
-                      var enlace = {
-                        from : result[0].id,
-                        to : nodeOfSecondType[0].id,
-                        value: dataParsed[n].relationWithSecondNode[r].widthOfEdge
-                      }
-                      dataEdges.push(enlace);
-                    } else {
-                      console.log("Error: Multiples nodes with same id finded");
-                    }
-                  }
-                }
-              } else {
-                console.log("Error: Multiples nodes with same id finded");
-              }
-            }
-            ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-            ////////////////////////////////////Creation the network with the library//////////////////////////////////
-            var nodesDataSet = new visN.DataSet(dataNodes);
-            var edgesDataSet = new visN.DataSet(dataEdges);
-
-            var container = document.getElementById(network_id);
-            container.style.height = container.getBoundingClientRect().height;
-            container.height = container.getBoundingClientRect().height;
-            var data = {
-              nodes: nodesDataSet,
-              edges: edgesDataSet
-            };
-            //If it is too much edges, chnage the options to better optimization
-            var options = {height: container.getBoundingClientRect().height.toString()};
-            if(dataEdges.length > 200){
-              var options = {
-                height: container.getBoundingClientRect().height.toString(),
-                physics:{
-                  barnesHut:{
-                    gravitationalConstant: $scope.vis.params.gravitationalConstant,
-                    springConstant: $scope.vis.params.springConstant
-                  }
-                },
-                "edges": {
-                  "smooth": {
-                    "forceDirection": "none",
-                    "type": "continuous"
-                  },
-                  scaling:{
-                    min:$scope.vis.params.minEdgeSize,
-                    max:$scope.vis.params.maxEdgeSize
-                  }
-                },
-                nodes: {
-                  scaling:{
-                    min:$scope.vis.params.minNodeSize,
-                    max:$scope.vis.params.maxNodeSize
-                  }
-                },
-                layout: {
-                  improvedLayout: false
-                },
-                interaction: {
-                  hover: true
-                }
-              };
-            }
-            console.log("Create network now");
-            var network = new visN.Network(container, data, options);
-
-            ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-            $scope.startDynamicResize(network);
-
-            network.on("afterDrawing", function (canvasP) {
-              $("#" + loading_id).hide();
-              /// Draw the color legend if Node Color is activated
-              if($scope.vis.aggs.bySchemaName['colornode'] && $scope.vis.params.showColorLegend){
-                $scope.drawColorLegend(usedColors, colorDicc);
-              }
-            });
-
-        }else if($scope.vis.aggs.bySchemaName['first'].length == 1 && $scope.vis.aggs.bySchemaName['second']){ //Node-Relation
-          $scope.initialShows();
-          $(".secondNode").hide();
-           // Retrieve the id of the configured tags aggregation
-          var firstFieldAggId = $scope.vis.aggs.bySchemaName['first'][0].id;
-          var secondFieldAggId = $scope.vis.aggs.bySchemaName['second'][0].id;
-
-          if($scope.vis.aggs.bySchemaName['colornode']){
-            var colorNodeAggId = $scope.vis.aggs.bySchemaName['colornode'][0].id;
-            var colorNodeAggName = $scope.vis.aggs.bySchemaName['colornode'][0].params.field.displayName;
-            var colorDicc = {};
-            var usedColors = [];
-
-            //Check if "Node Color" is the last selection
-            if($scope.vis.aggs.indexOf($scope.vis.aggs.bySchemaName['colornode'][0]) <= $scope.vis.aggs.indexOf($scope.vis.aggs.bySchemaName['second'][0])){
-              $scope.errorNodeColor();
-              return;
-            }
-          }
-
-          //Names of the terms that have been selected
-          var firstFieldAggName = $scope.vis.aggs.bySchemaName['first'][0].params.field.displayName;
-          var secondFieldAggName = $scope.vis.aggs.bySchemaName['second'][0].params.field.displayName;
-
-          // Retrieve the metrics aggregation configured
-          if($scope.vis.aggs.bySchemaName['size_node']){
-            var metricsAgg_sizeNode = $scope.vis.aggs.bySchemaName['size_node'][0];
-          }
-          if($scope.vis.aggs.bySchemaName['size_edge']){
-            var metricsAgg_sizeEdge = $scope.vis.aggs.bySchemaName['size_edge'][0];
-          }
-
-          // Get the buckets of that aggregation
-          if(resp.aggregations[firstFieldAggId]){
-            var buckets = resp.aggregations[firstFieldAggId].buckets;
-          }else{
-            var buckets = resp.aggregations[secondFieldAggId].buckets;
-          }
-
-          //////////////////////////////////////////////////DATA PARSED AND BULDING NODES//////////////////////////////////////////////////////////
-          var dataParsed = [];
-          // Iterate the buckets
-          var i = 0;
-          var dataNodes = buckets.map(function(bucket) {
-
-            dataParsed[i] = {};
-            dataParsed[i].keyNode = bucket.key;
-
-            //Metrics are for the sizes
-            if(metricsAgg_sizeNode){
-              // Use the getValue function of the aggregation to get the value of a bucket
-              var value = metricsAgg_sizeNode.getValue(bucket);
-              var sizeVal = Math.min($scope.vis.params.maxCutMetricSizeNode, value);
-
-              //No show nodes under the value
-              if($scope.vis.params.minCutMetricSizeNode > value){
-                dataParsed.splice(i, 1);
-                return;
-              }
-            }else{
-              var sizeVal = 20;
-            }
-
-            dataParsed[i].valorSizeNode = sizeVal;
-            dataParsed[i].nodeColorValue = "default";
-            dataParsed[i].nodeColorKey = "default";
-
-
-            //It depends of the priority of the selection to obtain the buckets
-            if(bucket[secondFieldAggId]){
-              var orderId = secondFieldAggId;
-            }else{
-              var orderId = firstFieldAggId;
-            }
-
-            dataParsed[i].relationWithSecondField = bucket[orderId].buckets.map(function(buck) {
-              if(metricsAgg_sizeEdge){
-                var value_sizeEdge = metricsAgg_sizeEdge.getValue(buck);
-                var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
-              }else{
-                var sizeEdgeVal = 0.1;
-              }
-
-              //Get the color of the node, save in the diccionary
-              if(colorNodeAggId && buck[colorNodeAggId].buckets.length > 0){
-                if(colorDicc[buck[colorNodeAggId].buckets[0].key]){
-                  dataParsed[i].nodeColorKey = buck[colorNodeAggId].buckets[0].key;
-                  dataParsed[i].nodeColorValue = colorDicc[buck[colorNodeAggId].buckets[0].key];
-                }else{
-                  while(true){
-                    var confirmColor = randomColor();
-                    if(usedColors.indexOf(confirmColor) == -1){
-                      colorDicc[buck[colorNodeAggId].buckets[0].key] = confirmColor;
-                      dataParsed[i].nodeColorValue = colorDicc[buck[colorNodeAggId].buckets[0].key];
-                      usedColors.push(confirmColor);
-                      break;
-                    }
-                  }
-
-                }
-              }
-
-              return {
-                keyRelation: buck.key,
-                countMetric: buck.doc_count,
-                widthOfEdge: sizeEdgeVal
-              };
-            });
-
-            var inPopup = "<p>" + bucket.key + "</p>"
-            if(dataParsed[i].nodeColorValue != "default"){
-              var colorNodeFinal = dataParsed[i].nodeColorValue;
-              inPopup += "<p>" + dataParsed[i].nodeColorKey + "</p>";
-            }else{
-              var colorNodeFinal = $scope.vis.params.firstNodeColor;
-            }
-
-            i++;
-            //Return the node totally builded
-            var nodeReturn = {
-              id: i,
-              key: bucket.key,
-              color: colorNodeFinal,
-              shape: $scope.vis.params.shapeFirstNode,
-              //size: sizeVal
-              value: sizeVal
-            }
-
-            //If activated, show the labels
-            if($scope.vis.params.showLabels){
-              nodeReturn.label = bucket.key;
-            }
-
-            //If activated, show the popus
-            if($scope.vis.params.showPopup){
-              nodeReturn.title = inPopup;
-            }
-
-            return nodeReturn;
-          });
-          //////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-          //////////////////////////////////////////////////BULDING EDGES//////////////////////////////////////////////////////////
-          //Clean "undefinded" in the array
-          dataNodes = dataNodes.filter(Boolean);
-          var dataEdges = [];
-
-          //Iterate parsed nodes
-          for(var n = 0; n<dataParsed.length; n++){
-            //Obtain id of the node
-            var NodoFrom = $.grep(dataNodes, function(e){ return e.key == dataParsed[n].keyNode;   });
-            if (NodoFrom.length == 0) {
-              console.log("Error: Node not finded");
-            } else if (NodoFrom.length == 1) {
-              var id_from = NodoFrom[0].id;
-              //Iterate relations that have with the second field selected
-              for(var p = 0; p<dataParsed[n].relationWithSecondField.length; p++){
-                //Iterate again the nodes
-                for(var z = 0; z<dataParsed.length; z++){
-                  //Check that we dont compare the same node
-                  if(dataParsed[n] != dataParsed[z]){
-                      var NodoTo = $.grep(dataNodes, function(e){ return e.key == dataParsed[z].keyNode;   });
-                      if (NodoTo.length == 0) {
-                        console.log("Error: Node not finded");
-                      } else if (NodoTo.length == 1) {
-                        var id_to = NodoTo[0].id;
-                        //Have relation?
-                        var sameRelation = $.grep(dataParsed[z].relationWithSecondField, function(e){ return e.keyRelation == dataParsed[n].relationWithSecondField[p].keyRelation;   });
-                        if (sameRelation.length == 1) {
-                          //Have relation the nodes, create the edge
-                          var edgeExist = $.grep(dataEdges, function(e){ return (e.to == id_from && e.from == id_to) || (e.to == id_to && e.from == id_from);   });
-                          if (edgeExist.length == 0) {
-                            //The size of the edge is the total of the common
-                            var sizeEdgeTotal = sameRelation[0].widthOfEdge + dataParsed[n].relationWithSecondField[p].widthOfEdge;
-                            var edge = {
-                              from : id_from,
-                              to : id_to,
-                              value: sizeEdgeTotal
-                            };
-                            dataEdges.push(edge);
-                          }
-                        }
-                      } else {
-                        console.log("Error: Multiples nodes with same id finded");
-                      }
-                  }
-                }
-              }
-
-            } else {
-              console.log("Error: Multiples nodes with same id finded");
-            }
-          }
-
-          //////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-          ////////////////////////////////////Creation the network with the library//////////////////////////////////
-          var nodesDataSet = new visN.DataSet(dataNodes);
-          var edgesDataSet = new visN.DataSet(dataEdges);
-
-
-          // Creation of the network
-          var container = document.getElementById(network_id);
-          //Set the Heigth
-          container.style.height = container.getBoundingClientRect().height;
-          container.height = container.getBoundingClientRect().height;
-          //Set the Data
-          var data = {
-            nodes: nodesDataSet,
-            edges: edgesDataSet
-          };
-          //Set the Options
-          var options = {
-            height: container.getBoundingClientRect().height.toString(),
-            physics: {
-              barnesHut: {
-                gravitationalConstant: $scope.vis.params.gravitationalConstant,
-                springConstant: $scope.vis.params.springConstant,
-                springLength: 500
-              }
-            },
-            "edges": {
-              "smooth": {
-                "type": "continuous"
-              },
-              scaling:{
-                min:$scope.vis.params.minEdgeSize,
-                max:$scope.vis.params.maxEdgeSize
-              }
-            },
-            interaction: {
-              hideEdgesOnDrag: true,
-              hover: true
-            },
-            nodes: {
-              scaling:{
-                min:$scope.vis.params.minNodeSize,
-                max:$scope.vis.params.maxNodeSize
-              }
-            },
-            layout: {
-              improvedLayout: false
-            }
-          }
-          console.log("Create network now");
-          var network = new visN.Network(container, data, options);
-          //////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-          $scope.startDynamicResize(network);
-
-          network.on("afterDrawing", function (canvasP) {
-            $("#" + loading_id).hide();
-            /// Draw the color legend if Node Color is activated
-            if($scope.vis.aggs.bySchemaName['colornode'] && $scope.vis.params.showColorLegend){
-              $scope.drawColorLegend(usedColors, colorDicc);
-            }
-          });
-
-        }else{
-          $scope.errorNodeNodeRelation();
+    // get the kibana/table_vis module, and make sure that it requires the "kibana" module if it
+    // didn't already
+    const module = require('ui/modules').get('kibana/network_vis', ['kibana']);
+
+    //import the npm modules
+    const visN = require('vis');
+    const randomColor = require('randomcolor');
+    const ElementQueries = require('css-element-queries/src/ElementQueries');
+    const ResizeSensor = require('css-element-queries/src/ResizeSensor');
+
+
+    // add a controller to the module, which will transform the esResponse into a
+    // tabular format that we can pass to the table directive
+    module.controller('KbnNetworkVisController', function ($scope, $sce, Private) {
+        var network_id = "net_" + $scope.$id;
+        var loading_id = "loading_" + $scope.$parent.$id;
+
+        $scope.errorNodeColor = function(){
+          $("#" + network_id).hide();
+          $("#" + loading_id).hide();
+          $("#errorHtml").html("<h1><strong>ERROR</strong>: Node Color must be the LAST selection</h1>");
+          $("#errorHtml").show();
         }
-      }
 
+        $scope.errorNodeNodeRelation = function(){
+          $("#" + network_id).hide();
+          $("#" + loading_id).hide();
+          $("#errorHtml").html("<h1><strong>ERROR</strong>: You can only choose Node-Node or Node-Relation</h1>");
+          $("#errorHtml").show();
+        }
+
+        $scope.initialShows = function(){
+          $("#" + network_id).show();
+          $("#" + loading_id).show();
+          $("#errorHtml").hide();
+        }
+
+        $scope.startDynamicResize = function(network){
+            for (i = 0; i < $(".vis-container" ).length; i++) {
+                if($(".vis-container")[i].children[0].children[1] && $(".vis-container")[i].children[0].children[1].id == network_id){
+                    var viscontainer = $(".vis-container")[i];
+                    break;
+                }
+            };
+            new ResizeSensor(viscontainer, function() {
+                network.setSize('100%', viscontainer.clientHeight);
+            });
+        }
+
+        $scope.drawColorLegend = function(usedColors, colorDicc){
+            var canvas = document.getElementsByTagName("canvas")[0];
+            var context = canvas.getContext("2d");
+
+            context.fillStyle="#FFE8D6";
+            var totalheight = usedColors.length * 25
+            context.fillRect(canvas.width*(-2)-10, canvas.height*(-2)-18, 350, totalheight);
+
+            context.fillStyle = "black";
+            context.font = "bold 30px Arial";
+            context.textAlign = "start";
+            context.fillText("LEGEND OF COLORS:", canvas.width*(-2), canvas.height*(-2));
+
+            var p=canvas.height*(-2) + 40;
+            for(var key in colorDicc){
+                context.fillStyle = colorDicc[key];
+                context.font = "bold 20px Arial";
+                context.fillText(key, canvas.width*(-2), p);
+                p = p +22;
+            }
+        }
+
+        $scope.$watchMulti(['esResponse', 'vis.params'], function ([resp]) {
+            if (resp) {
+                $("#" + loading_id).hide();
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////NODE-NODE Type///////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                if($scope.vis.aggs.bySchemaName['first'].length >= 1 && !$scope.vis.aggs.bySchemaName['second']){
+                    $scope.initialShows();
+                    $(".secondNode").show();
+                    // Retrieve the id of the configured tags aggregation
+                    var firstFieldAggId = $scope.vis.aggs.bySchemaName['first'][0].id;
+                    if($scope.vis.aggs.bySchemaName['first'].length > 1){
+                        var secondFieldAggId = $scope.vis.aggs.bySchemaName['first'][1].id;
+                    }
+
+                    if($scope.vis.aggs.bySchemaName['colornode']){
+                        var colorNodeAggId = $scope.vis.aggs.bySchemaName['colornode'][0].id;
+                        var colorNodeAggName = $scope.vis.aggs.bySchemaName['colornode'][0].params.field.displayName;
+                        var colorDicc = {};
+                        var usedColors = [];
+                    }
+
+                    //Names of the terms that have been selected
+                    var firstFieldAggName = $scope.vis.aggs.bySchemaName['first'][0].params.field.displayName;
+                    if($scope.vis.aggs.bySchemaName['first'].length > 1){
+                        var secondFieldAggName = $scope.vis.aggs.bySchemaName['first'][1].params.field.displayName;
+                    }
+
+                    // Retrieve the metrics aggregation configured
+                    if($scope.vis.aggs.bySchemaName['size_node']){
+                        var metricsAgg_sizeNode = $scope.vis.aggs.bySchemaName['size_node'][0];
+                    }
+                    if($scope.vis.aggs.bySchemaName['size_edge']){
+                        var metricsAgg_sizeEdge = $scope.vis.aggs.bySchemaName['size_edge'][0];
+                    }
+
+                    // Get the buckets of that aggregation
+                    var buckets = resp.aggregations[firstFieldAggId].buckets;
+
+///////////////////////////////////////////////////////////////DATA PARSED AND BUILDING NODES///////////////////////////////////////////////////////////////
+                    var dataParsed = [];
+                    // Iterate the buckets
+                    var i = 0;
+                    var dataNodes = buckets.map(function(bucket) {
+                        dataParsed[i] = {};
+                        dataParsed[i].keyFirstNode = bucket.key;
+
+                        //Metrics are for the sizes
+                        if(metricsAgg_sizeNode){
+                            // Use the getValue function of the aggregation to get the value of a bucket
+                            var value = metricsAgg_sizeNode.getValue(bucket);
+                            var sizeVal = Math.min($scope.vis.params.maxCutMetricSizeNode, value);
+
+                            //No show nodes under the value
+                            if($scope.vis.params.minCutMetricSizeNode > value){
+                                dataParsed.splice(i, 1);
+                                return;
+                            }
+                        }else{
+                            var sizeVal = 20;
+                        }
+
+                        dataParsed[i].valorSizeNode = sizeVal;
+                        dataParsed[i].nodeColorValue = "default";
+                        dataParsed[i].nodeColorKey = "default";
+
+
+                        //Iterate subbucket and choose the edge size
+                        if($scope.vis.aggs.bySchemaName['first'].length > 1){
+                            dataParsed[i].relationWithSecondNode = bucket[secondFieldAggId].buckets.map(function(buck) {
+                                if(metricsAgg_sizeEdge){
+                                    var value_sizeEdge = metricsAgg_sizeEdge.getValue(buck);
+                                    var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                }else{
+                                    var sizeEdgeVal = 0.1;
+                                }
+
+                                //Get the color of the node, save in the dictionary
+                                if(colorNodeAggId && buck[colorNodeAggId].buckets.length > 0){
+                                    if(colorDicc[buck[colorNodeAggId].buckets[0].key]){
+                                        dataParsed[i].nodeColorKey = buck[colorNodeAggId].buckets[0].key;
+                                        dataParsed[i].nodeColorValue = colorDicc[buck[colorNodeAggId].buckets[0].key];
+                                    }else{
+                                        //repeat to find a NO-REPEATED color
+                                        while(true){
+                                            var confirmColor = randomColor();
+                                            if(usedColors.indexOf(confirmColor) == -1){
+                                                colorDicc[buck[colorNodeAggId].buckets[0].key] = confirmColor;
+                                                dataParsed[i].nodeColorKey = buck[colorNodeAggId].buckets[0].key;
+                                                dataParsed[i].nodeColorValue = colorDicc[buck[colorNodeAggId].buckets[0].key];
+                                                usedColors.push(confirmColor);
+                                                break;
+                                            }
+                                        }
+
+                                    }
+                                }
+
+                                return {
+                                    keySecondNode: buck.key,
+                                    countMetric: buck.doc_count,
+                                    widthOfEdge: sizeEdgeVal
+                                };
+                            });
+                        }
+
+                        //assigning color and the content of the popup
+                        var inPopup = "<p>" + bucket.key + "</p>"
+                        if(dataParsed[i].nodeColorValue != "default"){
+                            var colorNodeFinal = dataParsed[i].nodeColorValue;
+                            inPopup += "<p>" + dataParsed[i].nodeColorKey + "</p>";
+                        }else{
+                            var colorNodeFinal = $scope.vis.params.firstNodeColor;
+                        }
+
+                        i++;
+                        //Return the node totally built
+                        var nodeReturn = {
+                            id: i,
+                            key: bucket.key,
+                            color: colorNodeFinal,
+                            shape: $scope.vis.params.shapeFirstNode,
+                            //size: sizeVal
+                            value: sizeVal
+                        }
+
+                        //If activated, show the labels
+                        if($scope.vis.params.showLabels){
+                            nodeReturn.label = bucket.key;
+                        }
+
+                        //If activated, show the popups
+                        if($scope.vis.params.showPopup){
+                            nodeReturn.title = inPopup;
+                        }
+
+                        return nodeReturn;
+                    });
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////BUILDING EDGES///////////////////////////////////////////////////////////////////////
+                    //Clean "undefined" in the array
+                    dataNodes = dataNodes.filter(Boolean);
+                    var dataEdges = [];
+                    for(var n = 0; n<dataParsed.length; n++){
+                        //Find in the array the node with the keyFirstNode
+                        var result = $.grep(dataNodes, function(e){ return e.key == dataParsed[n].keyFirstNode; });
+                        if (result.length == 0) {
+                            console.log("Error: Node not found");
+                        } else if (result.length == 1) {
+                            //Found the node, access to its id
+                            if($scope.vis.aggs.bySchemaName['first'].length > 1){
+                                for(var r = 0; r<dataParsed[n].relationWithSecondNode.length; r++){
+                                    //Find in the relations the second node to relate
+                                    var nodeOfSecondType = $.grep(dataNodes, function(e){ return e.key == dataParsed[n].relationWithSecondNode[r].keySecondNode; });
+                                    if (nodeOfSecondType.length == 0) {
+                                        //Not found, added to the DataNodes - node of type 2
+                                        i++;
+                                        var newNode = {
+                                            id : i,
+                                            key: dataParsed[n].relationWithSecondNode[r].keySecondNode,
+                                            label : dataParsed[n].relationWithSecondNode[r].keySecondNode,
+                                            color: $scope.vis.params.secondNodeColor,
+                                            shape: $scope.vis.params.shapeSecondNode
+                                        };
+                                        //Add new node
+                                        dataNodes.push(newNode);
+                                        //And create the relation (edge)
+                                        var edge = {
+                                            from : result[0].id,
+                                            to : dataNodes[dataNodes.length-1].id,
+                                            value: dataParsed[n].relationWithSecondNode[r].widthOfEdge
+                                        }
+                                        dataEdges.push(edge);
+
+                                    } else if (nodeOfSecondType.length == 1) {
+                                        //The node exists, creates only the edge
+                                        var enlace = {
+                                            from : result[0].id,
+                                            to : nodeOfSecondType[0].id,
+                                            value: dataParsed[n].relationWithSecondNode[r].widthOfEdge
+                                        }
+                                        dataEdges.push(enlace);
+                                    } else {
+                                        console.log("Error: Multiples nodes with same id found");
+                                    }
+                                }
+                            }
+                        } else {
+                            console.log("Error: Multiples nodes with same id found");
+                        }
+                    }
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+//////////////////////////////////////////////////////////Creation of the network with the library//////////////////////////////////////////////////////////
+                    var nodesDataSet = new visN.DataSet(dataNodes);
+                    var edgesDataSet = new visN.DataSet(dataEdges);
+
+                    var container = document.getElementById(network_id);
+                    container.style.height = container.getBoundingClientRect().height;
+                    container.height = container.getBoundingClientRect().height;
+                    var data = {
+                        nodes: nodesDataSet,
+                        edges: edgesDataSet
+                    };
+                    //CHANGE: Options controlled by user directly
+                    var options_1 = {
+                        height: container.getBoundingClientRect().height.toString(),
+                        physics:{
+                            barnesHut:{
+                                gravitationalConstant: $scope.vis.params.gravitationalConstant,
+                                springConstant: $scope.vis.params.springConstant
+                            }
+                        },
+                        edges:{
+                            arrowStrikethrough: false,
+                            smooth: {
+                                type: $scope.vis.params.smoothType
+                            },
+                            scaling:{
+                                min:$scope.vis.params.minEdgeSize,
+                                max:$scope.vis.params.maxEdgeSize
+                            }
+                        },
+                        nodes: {
+                            physics: $scope.vis.params.nodePhysics,
+                            scaling:{
+                                min:$scope.vis.params.minNodeSize,
+                                max:$scope.vis.params.maxNodeSize
+                            }
+                        },
+                        layout: {
+                            improvedLayout: !(dataEdges.length > 200)
+                        },
+                        interaction: {
+                            hover: true
+                        }
+                    };
+                    switch ($scope.vis.params.posArrow) {
+                        case 'from':
+                            var options_2 = {
+                                edges:{
+                                    arrows: {
+                                        from: {
+                                            enabled: $scope.vis.params.displayArrow,
+                                            scaleFactor: $scope.vis.params.scaleArrow,
+                                            type: $scope.vis.params.shapeArrow
+                                        }
+                                    }
+                                }
+                            };
+                            break;
+                        case 'middle':
+                            var options_2 = {
+                                edges:{
+                                    arrows: {
+                                        middle: {
+                                            enabled: $scope.vis.params.displayArrow,
+                                            scaleFactor: $scope.vis.params.scaleArrow,
+                                            type: $scope.vis.params.shapeArrow
+                                        }
+                                    }
+                                }
+                            };
+                            break;
+                        case 'to':
+                            var options_2 = {
+                                edges:{
+                                    arrows: {
+                                        to: {
+                                            enabled: $scope.vis.params.displayArrow,
+                                            scaleFactor: $scope.vis.params.scaleArrow,
+                                            type: $scope.vis.params.shapeArrow
+                                        }
+                                    }
+                                }
+                            };
+                            break;
+                        default:
+                            var options_2 = {
+                                edges:{
+                                    arrows: {
+                                        from: {
+                                            enabled: $scope.vis.params.displayArrow,
+                                            scaleFactor: $scope.vis.params.scaleArrow,
+                                            type: $scope.vis.params.shapeArrow
+                                        }
+                                    }
+                                }
+                            };
+                            break;
+                    }
+                    var options = angular.merge(options_1, options_2);
+                    console.log("Create network now");
+                    var network = new visN.Network(container, data, options);
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+                    $scope.startDynamicResize(network);
+
+                    network.on("afterDrawing", function (canvasP) {
+                        $("#" + loading_id).hide();
+                        // Draw the color legend if Node Color is activated
+                        if($scope.vis.aggs.bySchemaName['colornode'] && $scope.vis.params.showColorLegend){
+                            $scope.drawColorLegend(usedColors, colorDicc);
+                        }
+                    });
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////NODE-RELATION Type/////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                }else if($scope.vis.aggs.bySchemaName['first'].length == 1 && $scope.vis.aggs.bySchemaName['second']){
+                    $scope.initialShows();
+                    $(".secondNode").hide();
+                    // Retrieve the id of the configured tags aggregation
+                    var firstFieldAggId = $scope.vis.aggs.bySchemaName['first'][0].id;
+                    var secondFieldAggId = $scope.vis.aggs.bySchemaName['second'][0].id;
+
+                    if($scope.vis.aggs.bySchemaName['colornode']){
+                        var colorNodeAggId = $scope.vis.aggs.bySchemaName['colornode'][0].id;
+                        var colorNodeAggName = $scope.vis.aggs.bySchemaName['colornode'][0].params.field.displayName;
+                        var colorDicc = {};
+                        var usedColors = [];
+
+                        //Check if "Node Color" is the last selection
+                        if($scope.vis.aggs.indexOf($scope.vis.aggs.bySchemaName['colornode'][0]) <= $scope.vis.aggs.indexOf($scope.vis.aggs.bySchemaName['second'][0])){
+                            $scope.errorNodeColor();
+                            return;
+                        }
+                    }
+
+                    //Names of the terms that have been selected
+                    var firstFieldAggName = $scope.vis.aggs.bySchemaName['first'][0].params.field.displayName;
+                    var secondFieldAggName = $scope.vis.aggs.bySchemaName['second'][0].params.field.displayName;
+
+                    // Retrieve the metrics aggregation configured
+                    if($scope.vis.aggs.bySchemaName['size_node']){
+                        var metricsAgg_sizeNode = $scope.vis.aggs.bySchemaName['size_node'][0];
+                    }
+                    if($scope.vis.aggs.bySchemaName['size_edge']){
+                        var metricsAgg_sizeEdge = $scope.vis.aggs.bySchemaName['size_edge'][0];
+                    }
+
+                    // Get the buckets of that aggregation
+                    if(resp.aggregations[firstFieldAggId]){
+                        var buckets = resp.aggregations[firstFieldAggId].buckets;
+                    }else{
+                        var buckets = resp.aggregations[secondFieldAggId].buckets;
+                    }
+
+///////////////////////////////////////////////////////////////DATA PARSED AND BUILDING NODES///////////////////////////////////////////////////////////////
+                    var dataParsed = [];
+                    // Iterate the buckets
+                    var i = 0;
+                    var dataNodes = buckets.map(function(bucket) {
+                        dataParsed[i] = {};
+                        dataParsed[i].keyNode = bucket.key;
+
+                        //Metrics are for the sizes
+                        if(metricsAgg_sizeNode){
+                            // Use the getValue function of the aggregation to get the value of a bucket
+                            var value = metricsAgg_sizeNode.getValue(bucket);
+                            var sizeVal = Math.min($scope.vis.params.maxCutMetricSizeNode, value);
+
+                            //No show nodes under the value
+                            if($scope.vis.params.minCutMetricSizeNode > value){
+                                dataParsed.splice(i, 1);
+                                return;
+                            }
+                        }else{
+                            var sizeVal = 20;
+                        }
+
+                        dataParsed[i].valorSizeNode = sizeVal;
+                        dataParsed[i].nodeColorValue = "default";
+                        dataParsed[i].nodeColorKey = "default";
+
+
+                        //It depends of the priority of the selection to obtain the buckets
+                        if(bucket[secondFieldAggId]){
+                            var orderId = secondFieldAggId;
+                        }else{
+                            var orderId = firstFieldAggId;
+                        }
+
+                        dataParsed[i].relationWithSecondField = bucket[orderId].buckets.map(function(buck) {
+                            if(metricsAgg_sizeEdge){
+                                var value_sizeEdge = metricsAgg_sizeEdge.getValue(buck);
+                                var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                            }else{
+                                var sizeEdgeVal = 0.1;
+                            }
+
+                            //Get the color of the node, save in the dictionary
+                            if(colorNodeAggId && buck[colorNodeAggId].buckets.length > 0){
+                                if(colorDicc[buck[colorNodeAggId].buckets[0].key]){
+                                    dataParsed[i].nodeColorKey = buck[colorNodeAggId].buckets[0].key;
+                                    dataParsed[i].nodeColorValue = colorDicc[buck[colorNodeAggId].buckets[0].key];
+                                }else{
+                                    while(true){
+                                        var confirmColor = randomColor();
+                                        if(usedColors.indexOf(confirmColor) == -1){
+                                            colorDicc[buck[colorNodeAggId].buckets[0].key] = confirmColor;
+                                            dataParsed[i].nodeColorValue = colorDicc[buck[colorNodeAggId].buckets[0].key];
+                                            usedColors.push(confirmColor);
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            return {
+                                keyRelation: buck.key,
+                                countMetric: buck.doc_count,
+                                widthOfEdge: sizeEdgeVal
+                            };
+                        });
+
+                        var inPopup = "<p>" + bucket.key + "</p>"
+                        if(dataParsed[i].nodeColorValue != "default"){
+                            var colorNodeFinal = dataParsed[i].nodeColorValue;
+                            inPopup += "<p>" + dataParsed[i].nodeColorKey + "</p>";
+                        }else{
+                            var colorNodeFinal = $scope.vis.params.firstNodeColor;
+                        }
+
+                        i++;
+                        //Return the node totally built
+                        var nodeReturn = {
+                            id: i,
+                            key: bucket.key,
+                            color: colorNodeFinal,
+                            shape: $scope.vis.params.shapeFirstNode,
+                            //size: sizeVal
+                            value: sizeVal
+                        }
+
+                        //If activated, show the labels
+                        if($scope.vis.params.showLabels){
+                            nodeReturn.label = bucket.key;
+                        }
+
+                        //If activated, show the popups
+                        if($scope.vis.params.showPopup){
+                            nodeReturn.title = inPopup;
+                        }
+
+                        return nodeReturn;
+                    });
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////BUILDING EDGES///////////////////////////////////////////////////////////////////////
+                    //Clean "undefinded" in the array
+                    dataNodes = dataNodes.filter(Boolean);
+                    var dataEdges = [];
+
+                    //Iterate parsed nodes
+                    for(var n = 0; n<dataParsed.length; n++){
+                        //Obtain id of the node
+                        var NodoFrom = $.grep(dataNodes, function(e){ return e.key == dataParsed[n].keyNode; });
+                        if (NodoFrom.length == 0) {
+                            console.log("Error: Node not found");
+                        } else if (NodoFrom.length == 1) {
+                            var id_from = NodoFrom[0].id;
+                            //Iterate relations that have with the second field selected
+                            for(var p = 0; p<dataParsed[n].relationWithSecondField.length; p++){
+                                //Iterate again the nodes
+                                for(var z = 0; z<dataParsed.length; z++){
+                                //Check that we don't compare the same node
+                                    if(dataParsed[n] != dataParsed[z]){
+                                        var NodoTo = $.grep(dataNodes, function(e){ return e.key == dataParsed[z].keyNode; });
+                                        if (NodoTo.length == 0) {
+                                            console.log("Error: Node not found");
+                                        } else if (NodoTo.length == 1) {
+                                            var id_to = NodoTo[0].id;
+                                            //Have relation?
+                                            var sameRelation = $.grep(dataParsed[z].relationWithSecondField, function(e){ return e.keyRelation == dataParsed[n].relationWithSecondField[p].keyRelation;   });
+                                            if (sameRelation.length == 1) {
+                                                //Nodes have a relation, creating the edge
+                                                var edgeExist = $.grep(dataEdges, function(e){ return (e.to == id_from && e.from == id_to) || (e.to == id_to && e.from == id_from); });
+                                                if (edgeExist.length == 0) {
+                                                    //The size of the edge is the total of the common
+                                                    var sizeEdgeTotal = sameRelation[0].widthOfEdge + dataParsed[n].relationWithSecondField[p].widthOfEdge;
+                                                    var edge = {
+                                                        from : id_from,
+                                                        to : id_to,
+                                                        value: sizeEdgeTotal
+                                                    };
+                                                    dataEdges.push(edge);
+                                                }sdqs
+                                            }
+                                        } else {
+                                            console.log("Error: Multiples nodes with same id found");
+                                        }
+                                    }
+                                }
+                            }
+
+                        } else {
+                          console.log("Error: Multiples nodes with same id found");
+                        }
+                    }
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////Creation of the network with the library//////////////////////////////////////////////////////////
+                    var nodesDataSet = new visN.DataSet(dataNodes);
+                    var edgesDataSet = new visN.DataSet(dataEdges);
+
+
+                    // Creation of the network
+                    var container = document.getElementById(network_id);
+                    //Set the Height
+                    container.style.height = container.getBoundingClientRect().height;
+                    container.height = container.getBoundingClientRect().height;
+                    //Set the Data
+                    var data = {
+                        nodes: nodesDataSet,
+                        edges: edgesDataSet
+                    };
+                    //Set the Options
+                    var options = {
+                        height: container.getBoundingClientRect().height.toString(),
+                        physics: {
+                            barnesHut: {
+                                gravitationalConstant: $scope.vis.params.gravitationalConstant,
+                                springConstant: $scope.vis.params.springConstant,
+                                springLength: 500
+                            }
+                        },
+                        edges: {
+                            arrows: {
+                                to: {
+                                    enabled: $scope.vis.params.displayArrow,
+                                    scaleFactor: $scope.vis.params.scaleArrow,
+                                    type: $scope.vis.params.shapeArrow
+                                }
+                            },
+                            arrowStrikethrough: false,
+                            smooth: {
+                                type: $scope.vis.params.smoothType
+                            },
+                            scaling:{
+                                min:$scope.vis.params.minEdgeSize,
+                                max:$scope.vis.params.maxEdgeSize
+                            }
+                        },
+                        interaction: {
+                            hideEdgesOnDrag: true,
+                            hover: true
+                        },
+                        nodes: {
+                            physics: $scope.vis.params.nodePhysics,
+                            scaling:{
+                                min:$scope.vis.params.minNodeSize,
+                                max:$scope.vis.params.maxNodeSize
+                            }
+                        },
+                        layout: {
+                            improvedLayout: false
+                        }
+                    }
+                    console.log("Create network now");
+                    var network = new visN.Network(container, data, options);
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+                    $scope.startDynamicResize(network);
+
+                    network.on("afterDrawing", function (canvasP) {
+                        $("#" + loading_id).hide();
+                        // Draw the color legend if Node Color is activated
+                        if($scope.vis.aggs.bySchemaName['colornode'] && $scope.vis.params.showColorLegend){
+                            $scope.drawColorLegend(usedColors, colorDicc);
+                        }
+                    });
+
+                }else{
+                    $scope.errorNodeNodeRelation();
+                }
+            }
+        });
     });
-  });
-
 });

--- a/public/network_vis_controller.js
+++ b/public/network_vis_controller.js
@@ -558,7 +558,7 @@ define(function (require) {
                                                         value: sizeEdgeTotal
                                                     };
                                                     dataEdges.push(edge);
-                                                }sdqs
+                                                }
                                             }
                                         } else {
                                             console.log("Error: Multiples nodes with same id found");

--- a/public/network_vis_params.html
+++ b/public/network_vis_params.html
@@ -23,22 +23,26 @@
 <br>
 
 <h5><strong>Size</strong></h5>
-<div>
-  Max Node Size
-  <input type="number" ng-model="vis.params.maxNodeSize" min="1">
-</div>
-<div>
-  Min Node Size
-  <input type="number" ng-model="vis.params.minNodeSize" min="1">
-</div>
-<div>
-  Max Edge Width
-  <input type="number" ng-model="vis.params.maxEdgeSize" min="1">
-</div>
-<div>
-  Min Edge Width
-  <input type="number" ng-model="vis.params.minEdgeSize" min="0.1">
-</div>
+<table>
+    <tbody>
+        <tr>
+            <td>Max Node Size&nbsp;</td>
+            <td><input type="number" ng-model="vis.params.maxNodeSize" min="1"></td>
+        </tr>
+        <tr>
+            <td>Min Node Size&nbsp;</td>
+            <td><input type="number" ng-model="vis.params.minNodeSize" min="1"></td>
+        </tr>
+        <tr>
+            <td>Max Edge Width&nbsp;</td>
+            <td><input type="number" ng-model="vis.params.maxEdgeSize" min="1"></td>
+        </tr>
+        <tr>
+            <td>Min Edge Width&nbsp;</td>
+            <td><input type="number" ng-model="vis.params.minEdgeSize" min="0.1"></td>
+        </tr>
+    </tbody>
+</table>
 
 <br>
 
@@ -79,6 +83,58 @@
 
 <br>
 
+<h5><strong>Directional Edges</strong></h5>
+<table>
+    <tbody>
+        <tr>
+            <td>Display directional edge:&nbsp;</td>
+            <td><input type="checkbox" ng-model="vis.params.displayArrow"></td>
+        </tr>
+        <tr>
+            <td>Endpoint position:&nbsp;</td>
+            <td>
+                <select class="form-control" ng-model="vis.params.posArrow" id="sel4">
+                    <option value="from">Beginning</option>
+                    <option value="middle">Middle</option>
+                    <option value="to">End side</option>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <td>Endpoint Type:</td>
+            <td>
+                <select class="form-control" ng-model="vis.params.shapeArrow" id="sel3">
+                    <option value="arrow">Arrow</option>
+                    <option value="circle">Circle</option>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <td>Scale Factor:</td>
+            <td><input type="number" ng-model="vis.params.scaleArrow" min="0"></td>
+        </tr>
+        <tr>
+            <td>Smooth type:</td>
+            <td>
+                <select class="form-control" ng-model="vis.params.smoothType" id="sel5">
+                    <option value="dynamic">Dynamic</option>
+                    <option value="continuous">Continuous Anchor</option>
+                    <option value="discrete">Discrete Anchor</option>
+                    <option value="diagonalCross">Diagonal Anchor</option>
+                    <option value="straightCross">Straight Line</option>
+                    <option value="horizontal">Horizontal Anchor</option>
+                    <option value="vertical">Vertical Anchor</option>
+                    <option value="curvedCW">Clock-wise Curve</option>
+                    <option value="curvedCCW">Counter-Clock-wise Curve</option>
+                    <option value="cubicBezier">Cubic Bezier</option>
+                </select>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<br>
+
 <h5><strong>Extra</strong></h5>
 <div class="checkbox">
   <label>
@@ -93,17 +149,21 @@
     <input type="checkbox" ng-model="vis.params.showColorLegend">
     Show Color Legend (Node Color selected)
   </label>
+  <label>
+    <input type="checkbox" ng-model="vis.params.nodePhysics">
+    Nodes Acting like Springs
+  </label>
 </div>
 
 <br>
 
 <h5><strong>Network constants</strong></h5>
 <div>
-  Gravitational
+  Attraction Force
   <input type="number" ng-model="vis.params.gravitationalConstant" id="gravC">
 </div>
 <div>
-  Spring
+  Spring Force
   <input type="number" ng-model="vis.params.springConstant" id="springC">
 </div>
 


### PR DESCRIPTION
Package.json has been modified to be v5.3.0.
Dependencies of randomcolor and vis.js has been updated.

Plugin has been modified to display new option for the user, such as:
-disable physics
-enable directional edges
-edge type

Moreover, the behavior that has been reserved for networks with 200+ edges is now the default one (to use the options provided by the user).
As I changed indent. on file, it does not display properly changes made on diff mode. 
On network_vis_controller.js, I only changed the use of var options (lines at ~180 and lines at ~590).

These changes concerning edges were made because, at the current state, a small graph with quite high number of edges was not easily readable.
Moreover, disabling physics and putting directional edges with CW curve make the graph behave like a state diagram, making it great for tracking action, or something else.

Actual State:
![then](https://cloud.githubusercontent.com/assets/22025789/25219286/2bb17a3c-25ae-11e7-801b-9a732c65cdda.png)
(Cannot space the nodes due to the physics and constants given only applies with 200+ edges)

With the new options:
![now](https://cloud.githubusercontent.com/assets/22025789/25219371/8fda838c-25ae-11e7-968b-6b19b29beeb8.png)
 (certainly not perfect, but I find it easier to read. Next step would be to also let the user choose colors, but would maybe require some work)

This said, great job with this plugin

(1st time submitting a pull request, if there is any problem, just notify me)

