### PR TITLE
Dynamic element Ids for 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Network Plugin for Kibana 5
+# Network Plugin for Kibana 4.x
 
 This is a plugin developed for Kibana 5 that displays a network node that link two fields that have been previously selected.
 
@@ -7,17 +7,11 @@ This is a plugin developed for Kibana 5 that displays a network node that link t
 ##Installation Steps
 
 ```
-cd KIBANA_HOME/plugins
-```
-> If the **plugins** folder does not exist, change to **installedPlugins** and continue.
-
-```
-git clone https://github.com/dlumbrer/kbn_network.git network_vis
+cd KIBANA_HOME/installedPlugins
+git clone -b 4.x https://github.com/dlumbrer/kbn_network.git network_vis
 cd network_vis
 npm install
 ```
-> **Important:** If you have any problem with the plugin version (like a warning message "**it expected Kibana version "x.x.x", and found "5.0.0-rc1"**") only change the value of the "version" tag on the package.json to your Kibana version
-
 
 ####Unistall:
 ```

--- a/public/network_vis.html
+++ b/public/network_vis.html
@@ -1,7 +1,7 @@
 <div id="errorHtml"></div>
-<div ng-controller="KbnNetworkVisController" class="network-vis" id="mynetwork" ng-style="{'background-color':vis.params.canvasBackgroundColor}">
+<div ng-controller="KbnNetworkVisController" class="network-vis" id="net_{{$id}}" ng-style="{'background-color':vis.params.canvasBackgroundColor}">
 </div>
-<div id="loading" ng-style="{'background-color':vis.params.canvasBackgroundColor}">
+<div id="loading_{{$id}}" ng-style="{'background-color':vis.params.canvasBackgroundColor}">
   <div class="loading_msg">
     <p><strong>Loading network...</strong><i class="fa fa-clock-o" aria-hidden="true"></i></p>
   </div>

--- a/public/network_vis_controller.js
+++ b/public/network_vis_controller.js
@@ -40,7 +40,7 @@ define(function (require) {
 
     $scope.startDynamicResize = function(network){
       for (i = 0; i < $(".vis-container" ).length; i++) {
-         if($(".vis-container")[i].children[0].children[1] && $(".vis-container")[i].children[0].children[1].id == "mynetwork"){
+         if($(".vis-container")[i].children[0].children[1] && $(".vis-container")[i].children[0].children[1].id == network_id){
            var viscontainer = $(".vis-container")[i];
            break;
          }
@@ -271,7 +271,7 @@ define(function (require) {
             var nodesDataSet = new visN.DataSet(dataNodes);
             var edgesDataSet = new visN.DataSet(dataEdges);
 
-            var container = document.getElementById('mynetwork');
+            var container = document.getElementById(network_id);
             container.style.height = container.getBoundingClientRect().height;
             container.height = container.getBoundingClientRect().height;
             var data = {
@@ -529,7 +529,7 @@ define(function (require) {
           var edgesDataSet = new visN.DataSet(dataEdges);
 
           // Creation of the network
-          var container = document.getElementById('mynetwork');
+          var container = document.getElementById(network_id);
           //Set the Heigth
           container.style.height = container.getBoundingClientRect().height;
           container.height = container.getBoundingClientRect().height;

--- a/public/network_vis_controller.js
+++ b/public/network_vis_controller.js
@@ -13,25 +13,28 @@ define(function (require) {
   // add a controller to tha module, which will transform the esResponse into a
   // tabular format that we can pass to the table directive
   module.controller('KbnNetworkVisController', function ($scope, $sce, Private) {
+    
+    var network_id = "net_" + $scope.$id;
+    var loading_id = "loading_" + $scope.$parent.$id;
 
     $scope.errorNodeColor = function(){
-      $("#mynetwork").hide();
-      $("#loading").hide();
+      $("#" + network_id).hide();
+      $("#" + loading_id).hide();
       $("#errorHtml").html("<h1><strong>ERROR</strong>: Node Color must be the LAST selection</h1>");
       $("#errorHtml").show();
 
     }
 
     $scope.errorNodeNodeRelation = function(){
-      $("#mynetwork").hide();
-      $("#loading").hide();
+      $("#" + network_id).hide();
+      $("#" + loading_id).hide();
       $("#errorHtml").html("<h1><strong>ERROR</strong>: You can only choose Node-Node or Node-Relation</h1>");
       $("#errorHtml").show();
     }
 
     $scope.initialShows = function(){
-      $("#mynetwork").show();
-      $("#loading").show();
+      $("#" + network_id).show();
+      $("#" + loading_id).show();
       $("#errorHtml").hide();
     }
 
@@ -72,7 +75,7 @@ define(function (require) {
 
    $scope.$watchMulti(['esResponse', 'vis.params'], function ([resp]) {
       if (resp) {
-        $("#loading").hide();
+        $("#" + loading_id).hide();
         if($scope.vis.aggs.bySchemaName['first'].length >= 1 && !$scope.vis.aggs.bySchemaName['second']){ //This is when we have 2 nodes
             $scope.initialShows();
             $(".secondNode").show();
@@ -318,7 +321,7 @@ define(function (require) {
             $scope.startDynamicResize(network);
 
             network.on("afterDrawing", function (canvasP) {
-              $("#loading").hide();
+              $("#" + loading_id).hide();
               /// Draw the color legend if Node Color is activated
               if($scope.vis.aggs.bySchemaName['colornode'] && $scope.vis.params.showColorLegend){
                 $scope.drawColorLegend(usedColors, colorDicc);
@@ -575,7 +578,7 @@ define(function (require) {
           $scope.startDynamicResize(network);
 
           network.on("afterDrawing", function (canvasP) {
-            $("#loading").hide();
+            $("#" + loading_id).hide();
             /// Draw the color legend if Node Color is activated
             if($scope.vis.aggs.bySchemaName['colornode'] && $scope.vis.params.showColorLegend){
               $scope.drawColorLegend(usedColors, colorDicc);


### PR DESCRIPTION
This PR back-ports dynamic ids for elements to support multiple instances of the Viz per dashboard, and adjusts the readme and instructions for those still using 4.x here and there for whatever reason.