### PR TITLE
Kibana 7.2 fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,64 @@
+{
+  "name": "network_vis",
+  "version": "5.5.0-1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "css-element-queries": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/css-element-queries/-/css-element-queries-0.3.2.tgz",
+      "integrity": "sha1-U12AiRs68hOV0AXxmQX+UVS1zP8="
+    },
+    "keycharm": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
+      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "randomcolor": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/randomcolor/-/randomcolor-0.5.0.tgz",
+      "integrity": "sha1-Gn3eS4U6F4ujTU5ND8c5K47HLjw="
+    },
+    "vis-data": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-6.3.5.tgz",
+      "integrity": "sha512-H8lD1NTmC5HimYeqTouxhbUya5qrYQGjpJhIHkxsm5R34EEdcm/D1cLTMLFFyIoZC6SQkADQj+dlFKf5DOnSww==",
+      "requires": {
+        "vis-util": "2.0.1",
+        "vis-uuid": "1.1.3"
+      },
+      "dependencies": {
+        "vis-util": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-2.0.1.tgz",
+          "integrity": "sha512-VBQ6zCT+Iaum70uzLbjk0nLMOjp9NhPzU42j0gaM6q6tg0eTcgIWNXzAqamhQtmm1kDj0jMLzKvkFOPENYv34w==",
+          "optional": true
+        }
+      }
+    },
+    "vis-network": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-7.2.0.tgz",
+      "integrity": "sha512-K8Ju5oW26LosuEYPZw+dQD7L2WHNdhcEbiik5x1VA2kxIB4VJdIo0tOlXm8YpKeecahf/9egMCHEzu7J+a9I9w=="
+    },
+    "vis-util": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-1.1.10.tgz",
+      "integrity": "sha512-8hGSxsFi2ogYYweClQyITzWnirWgQ8p0i9M4d3OXMuUO8vjXrf+2zHOYI9OZbtUduxAWuMEePnS9BXDtPJmJ7Q==",
+      "requires": {
+        "moment": "2.24.0",
+        "vis-uuid": "1.1.3"
+      }
+    },
+    "vis-uuid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vis-uuid/-/vis-uuid-1.1.3.tgz",
+      "integrity": "sha512-2B6XdY1bkzbUh+TugmnAaFa61KO9R5pzBzIuFIm8a9FrkbxIdSmQXV+FbfkL8QunkQV/bT0JDLQ2puqCS2+0Og=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "dependencies" : {
     "vis-network": "7.2.0",
     "randomcolor": "0.5.0",
-    "css-element-queries": "0.3.2"
+    "css-element-queries": "0.3.2",
+    "keycharm": "^0.2.0",
+    "moment": "^2.24.0",
+    "vis-data": "^6.3.5",
+    "vis-util": "^1.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
     "version": "kibana"
   },
   "authors": [
-  "David Moreno Lumbreras <dmorenolumb@gmail.com>"
+    "David Moreno Lumbreras <dmorenolumb@gmail.com>"
   ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dlumbrer/kbn_network"
   },
-  "dependencies" : {
+  "dependencies": {
     "vis-network": "7.2.0",
     "randomcolor": "0.5.0",
     "css-element-queries": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/dlumbrer/kbn_network"
   },
   "dependencies" : {
-    "vis": "4.16.1",
+    "vis-network": "7.2.0",
     "randomcolor": "0.5.0",
     "css-element-queries": "0.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "css-element-queries": "0.3.2",
     "keycharm": "^0.2.0",
     "moment": "^2.24.0",
-    "vis-data": "^6.3.5",
+    "vis-data": "^6.2.1",
     "vis-util": "^1.1.8"
   }
 }

--- a/public/network_vis_controller.js
+++ b/public/network_vis_controller.js
@@ -4,7 +4,7 @@ import { uiModules } from 'ui/modules';
 // didn't already
 const module = uiModules.get('kibana/transform_vis', ['kibana']);
 //import the npm modules
-const visN = require('vis');
+const visN = require('vis-network');
 const randomColor = require('randomcolor');
 const ElementQueries = require('css-element-queries/src/ElementQueries');
 const ResizeSensor = require('css-element-queries/src/ResizeSensor');
@@ -153,7 +153,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if (metricsAgg_sizeNode) {
                                 // Use the getValue function of the aggregation to get the value of a bucket
                                 var value = bucket[nodeSizeId]//metricsAgg_sizeNode.getValue(bucket);
-                                var sizeVal = Math.min($scope.vis.params.maxCutMetricSizeNode, value);
+                                var sizeVal = Math.max($scope.vis.params.maxCutMetricSizeNode, value);
 
                                 //No show nodes under the value
                                 if ($scope.vis.params.minCutMetricSizeNode > value) {
@@ -176,7 +176,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if ($scope.vis.aggs.bySchemaName['first'].length > 1) {
                                 if (metricsAgg_sizeEdge) {
                                     var value_sizeEdge = bucket[edgeSizeId];
-                                    var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                    var sizeEdgeVal = Math.max($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
                                 } else {
                                     var sizeEdgeVal = 0.1;
                                 }
@@ -252,7 +252,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if ($scope.vis.aggs.bySchemaName['first'].length > 1) {
                                 if (metricsAgg_sizeEdge) {
                                     var value_sizeEdge = bucket[edgeSizeId];
-                                    var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                    var sizeEdgeVal = Math.max($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
                                 } else {
                                     var sizeEdgeVal = 0.1;
                                 }
@@ -496,7 +496,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if (metricsAgg_sizeNode) {
                                 // Use the getValue function of the aggregation to get the value of a bucket
                                 var value = bucket[nodeSizeId];
-                                var sizeVal = Math.min($scope.vis.params.maxCutMetricSizeNode, value);
+                                var sizeVal = Math.max($scope.vis.params.maxCutMetricSizeNode, value);
 
                                 //No show nodes under the value
                                 if ($scope.vis.params.minCutMetricSizeNode > value) {
@@ -515,7 +515,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             //RELATION//////////////////////////////
                             if (metricsAgg_sizeEdge) {
                                 var value_sizeEdge = bucket[edgeSizeId];
-                                var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                var sizeEdgeVal = Math.max($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
                             } else {
                                 var sizeEdgeVal = 0.1;
                             }
@@ -588,7 +588,7 @@ module.controller('KbnNetworkVisController', function ($scope, $sce, $timeout, P
                             if ($scope.vis.aggs.bySchemaName['second'].length > 0) {
                                 if (metricsAgg_sizeEdge) {
                                     var value_sizeEdge = bucket[edgeSizeId];
-                                    var sizeEdgeVal = Math.min($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
+                                    var sizeEdgeVal = Math.max($scope.vis.params.maxCutMetricSizeEdge, value_sizeEdge);
                                 } else {
                                     var sizeEdgeVal = 0.1;
                                 }


### PR DESCRIPTION
* Replace deprecated vis library
Almende/vis is at end of life and also produced this [bug](https://github.com/almende/vis/issues/3899)
visjs/vis-network is actively developed, uses the same API, and only needed to be imported 

* Fix "Top Values" selection for node/edge bucketing and sizing.
We often have large data results being returned for aggregations (greater than the default 5000), and Math.min is being used to choose between the default 5000 or the maxCutMetricSize returned by our results. This results in 5000 being used as the top value for node/edge size, which makes any results above that appear to be equally sized. For example, using `Count` on a Field like `SrcIP` could return IP addresses with 20,000, 10,000, and 5,000 hits in our data set, which would all be equally sized as large nodes. This PR switches Math.min to Math.max.

Tagging @craig-cogdill as a collaborator
 