### PR TITLE
Fix node color buckets

### DIFF
--- a/public/kbn-network-vis.js
+++ b/public/kbn-network-vis.js
@@ -124,7 +124,6 @@ export function kbnNetworkVisTypeDefinition(core, context) {
           group: AggGroupNames.Buckets,
           name: 'colornode',
           title: "Node Color",
-          mustBeFirst: 'true',
           max: 1,
           aggFilter: ['terms']
         }


### PR DESCRIPTION
Color buckets can't be added because both them and normal node buckets have the `mustBeFirst` condition:
![imagen](https://user-images.githubusercontent.com/26812577/170472744-0b9ed24d-d24d-4743-92c0-081d9f6e99fa.png)
![imagen](https://user-images.githubusercontent.com/26812577/170472764-7d47fded-8f82-4818-a1ac-fef7cc5845c5.png)

This PR removes the attribute from the node color buckets.