### PR TITLE
Editable color node palette

### DIFF
--- a/public/kbn_network.scss
+++ b/public/kbn_network.scss
@@ -41,3 +41,41 @@ div.vis-tooltip {
   text-align: center;
   line-height: 40px;
 }
+
+.vis-network-legend {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: rgba(218, 218, 218, 0.25);
+  padding: 12px;
+  font-size: 14px;
+
+  .vis-network-legend-line {
+    display: flex;
+    align-items: center;
+
+    input {
+      visibility: hidden;
+      width: 0;
+      height: 0;
+    }
+
+    label {
+      display: flex;
+      align-items: center;
+      padding: 3px;
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
+      }
+
+      .vis-network-legend-color {
+        width: 15px;
+        height: 15px;
+        border-radius: 50%;
+        margin-right: 6px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the feature requested at #26. The colors are loaded from the [Elastic UI color palette](https://elastic.github.io/eui/#/utilities/color-palettes) to match the rest of the charts and are saved to the plugin's state so that they are kept even if the visualization is refreshed. When it runs out of EUI colors, it generates a random color.
Each color can also be set individually by clicking on the legend, which opens the browser's default color picker.
Here is a small demo of what the feature looks like:
![network](https://user-images.githubusercontent.com/26812577/175982200-f69a9a83-481a-4990-b12f-e2486d893ecd.gif)
The changes have been tested on OpenSearch Dashboards 1.3.2.
 